### PR TITLE
Use label to style input

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ Instead of that boring old stock file selector, your users will see
 this:
 
 <div style="position: relative; display: inline-block;">
-<img style="pointer-events: none; display: block; border-radius: 10px;" src="http://i.imgur.com/Mj0xj.jpg" alt="I should buy a boat"/>
-<input type="file" name="files" alt="Choose a File" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; opacity: 0; z-index: 1;"/>
+  <img style="pointer-events: none; display: block; border-radius: 10px;" src="http://i.imgur.com/Mj0xj.jpg" alt="I should buy a boat"/>
+  <input type="file" name="files" alt="Choose a File" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; opacity: 0; z-index: 1;"/>
 </div>
 
-And don't worry, that custom trigger will be hidden from screen
-readers, so the file input remains 100% accessible.
+And don't worry, that custom trigger is a form label, so the file input remains
+100% accessible.
 
 
 ## EmberX

--- a/addon/components/x-file-input.js
+++ b/addon/components/x-file-input.js
@@ -15,7 +15,11 @@ export default Ember.Component.extend({
    * @method
    * @param {$.Event} e Native change event
    */
-  change: function(e) {
+  change(e) {
     this.sendAction("action", e.target.files);
-  }
+  },
+
+  randomId: Ember.computed(function() {
+    return Math.random().toString(36).substring(7);
+  })
 });

--- a/addon/templates/components/x-file-input.hbs
+++ b/addon/templates/components/x-file-input.hbs
@@ -1,6 +1,10 @@
-{{input id="x_file_input" type="file" class="x-file--input" name=name
+{{input id=randomId type="file" class="x-file--input" name=name
   disabled=disabled multiple=multiple tabindex=tabindex}}
 
-<label for="x_file_input">
-  {{yield}}
+<label for="{{randomId}}">
+  {{#if hasBlock}}
+    {{yield}}
+  {{else}}
+    {{alt}}
+  {{/if}}
 </label>

--- a/addon/templates/components/x-file-input.hbs
+++ b/addon/templates/components/x-file-input.hbs
@@ -1,6 +1,6 @@
-{{#if hasBlock}}
-  <div class="spec-file-input__content" aria-hidden="true">
-    {{yield}}
-  </div>
-{{/if}}
-{{input type="file" class="x-file--input" name=name disabled=disabled multiple=multiple tabindex=tabindex}}
+{{input id="x_file_input" type="file" class="x-file--input" name=name
+  disabled=disabled multiple=multiple tabindex=tabindex}}
+
+<label for="x_file_input">
+  {{yield}}
+</label>

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "emberx-file-input",
   "dependencies": {
-    "ember": "1.11.0",
+    "ember": "1.13.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-mocha": "~0.8.0",
     "chai-jquery": "~2.0.0",

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "emberx-file-input",
   "dependencies": {
-    "ember": "1.13.0",
+    "ember": "1.11.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-mocha": "~0.8.0",
     "chai-jquery": "~2.0.0",

--- a/tests/acceptance/x-file-input-test.js
+++ b/tests/acceptance/x-file-input-test.js
@@ -17,10 +17,11 @@ describe('Acceptance: XFileInput', function() {
   });
 
   beforeEach(function() {
-    visit('/');
-    return andThen(() => {
-      this.component = getComponentById('spec-file-input');
-    });
+    return visit('/');
+  });
+
+  beforeEach(function() {
+    this.component = getComponentById('spec-file-input');
   });
 
   it('renders', function() {
@@ -33,10 +34,6 @@ describe('Acceptance: XFileInput', function() {
 
   it('has 0 tab index', function() {
     expect(this.component.$('input[type=file]')).to.have.attr('tabindex', '0');
-  });
-
-  it('has aria-hidden around its content', function() {
-    expect(this.component.$('.spec-file-input__content')).to.have.attr('aria-hidden', 'true');
   });
 
   it('has contains its yielded content', function() {

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,13 +1,9 @@
-.custom-container {
-  width: 70%;
-}
-
-.custom {
+.custom-class label {
   background: green;
-  border: none;
+  padding: 10px;
   color: white;
-  font-size: 20px;
-  padding: 40px;
-  text-align: center;
-  border-radius: 6px;
+}
+.x-file--input:focus + label,
+.custom-class label:hover {
+  background-color: blue;
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -2,6 +2,6 @@
 
 {{outlet}}
 
-{{#x-file-input class="custom-container" action="tryAnUpload" id="spec-file-input"}}
-  <button class="custom">Shall you upload?</button>
+{{#x-file-input class="custom-class" action="tryAnUpload" id="spec-file-input"}}
+  <h3>Shall you upload?</h3>
 {{/x-file-input}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,7 +1,16 @@
 <h2 id="title">Welcome to emberx-file-input</h2>
 
-{{outlet}}
 
-{{#x-file-input class="custom-class" action="tryAnUpload" id="spec-file-input"}}
-  <h3>Shall you upload?</h3>
-{{/x-file-input}}
+<div style="margin-bottom: 10px;">
+  {{#x-file-input class="custom-class" action="tryAnUpload" id="spec-file-input"}}
+    <h3>Shall you upload?</h3>
+  {{/x-file-input}}
+</div>
+
+<div>
+  Non block:
+  {{x-file-input class="custom-class" alt="Upload Something!"
+    action="tryAnUpload" id="spec-file-input-blockless"}}
+</div>
+
+{{outlet}}

--- a/vendor/style.css
+++ b/vendor/style.css
@@ -1,27 +1,28 @@
-.x-file {
-  position: relative;
+/* Hide the original input */
+.x-file--input {
+  width: 0.1px;
+  height: 0.1px;
+  opacity: 0;
   overflow: hidden;
-  display: inline-block;
-}
-
-.x-file > * {
-  min-width: 100%;
-  min-height: 100%;
-}
-
-.x-file--input{
   position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  text-align: right;
-  filter: alpha(opacity=0);
-  /*opacity: 0; commented out for testing*/
-  outline: none;
-  background: rgba(255, 0, 0, 0.33); /*Added opaque background for testing*/
-  cursor: inherit;
-  display: block;
-  font-size: inherit;
+  z-index: -1;
 }
 
+.x-file--input + label {
+  display: inline-block;
+  cursor: pointer;
+}
+
+.x-file--input:focus + label,
+.x-file--input + label:hover {
+  /* Overwrite this in your own css file with styles for :focus & :hover  */
+}
+
+.x-file--input:focus + label {
+  outline: 1px dotted #000;
+  outline: -webkit-focus-ring-color auto 5px;
+}
+
+.x-file--input + label * {
+  pointer-events: none;
+}


### PR DESCRIPTION
Thanks to [this blog post](http://tympanus.net/codrops/2015/09/15/styling-customizing-file-inputs-smart-way/) we are now using a better way to style input fields.

Unfortunately this ups the minimum version of Ember back up to 1.13 since we have to check for a block.

Also caught a bug where you couldn't have more than 1 of these components on a page due to them having the same ID. Short sighted, I know. It's fixed now with a randomly generated ID.