### PR TITLE
Fix mobile Safari styling bug for hidden file input element

### DIFF
--- a/vendor/style.css
+++ b/vendor/style.css
@@ -2,6 +2,7 @@
 .x-file--input {
   width: 0px;
   height: 0px;
+  max-width: 0;
   opacity: 0;
   overflow: hidden;
   z-index: -1;


### PR DESCRIPTION
Added `max-width: 0` rule to default styles, to ensure the width of the hidden file input doesn't spill out, and cause a whitespace gutter.

This fix solves issue https://github.com/thefrontside/emberx-file-input/issues/16.