### PR TITLE
Add possibility to reset file field after submit

### DIFF
--- a/addon/components/x-file-input.js
+++ b/addon/components/x-file-input.js
@@ -7,7 +7,6 @@ export default Ember.Component.extend({
   tagName: 'span',
   layout: layout,
   tabindex: 0,
-  files:
 
   /**
    * Listens for change events on the native file input and dispatches

--- a/addon/components/x-file-input.js
+++ b/addon/components/x-file-input.js
@@ -18,6 +18,9 @@ export default Ember.Component.extend({
    */
   change(e) {
     this.sendAction("action", e.target.files);
+    if (this.get('reset')) {
+      this.$().replaceWith(this.$().val('').clone(true));
+    }
   },
 
   randomId: Ember.computed(function() {

--- a/addon/components/x-file-input.js
+++ b/addon/components/x-file-input.js
@@ -7,6 +7,7 @@ export default Ember.Component.extend({
   tagName: 'span',
   layout: layout,
   tabindex: 0,
+  files:
 
   /**
    * Listens for change events on the native file input and dispatches
@@ -18,7 +19,7 @@ export default Ember.Component.extend({
    */
   change(e) {
     this.sendAction("action", e.target.files);
-    if (this.get('reset')) {
+    if (this.get('resetInput')) {
       this.$().replaceWith(this.$().val('').clone(true));
     }
   },

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-data": "1.13.8",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-resolver": "~0.1.18",
-    "jquery": "1.11.3",
+    "jquery": "^1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-data": "1.13.8",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1"
   }
 }


### PR DESCRIPTION
It's a small change based on this issue:
https://github.com/thefrontside/emberx-file-input/issues/23

It allows to set additional property - `reset` if we want to reset `input` field right after sending an action. This allows us to upload the same file multiple times which may be useful in some cases.