### PR TITLE
Update included hook for nested addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,6 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    app.import('vendor/style.css');
+    this.import('vendor/style.css');
   }
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "ember-cli-github-pages": "0.0.6",
     "ember-cli-htmlbars-inline-precompile": "^0.2.0",
     "ember-cli-ic-ajax": "0.2.1",
+    "ember-cli-import-polyfill": "0.1.0",
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-mocha": "~0.8.0",
     "ember-cli-release": "0.2.3",


### PR DESCRIPTION
This PR fixes the included hook so `emberx-file-input` can be used as a dependency of another addon.

