### PR TITLE
Add the ability to reset the file input

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,15 @@ invoked with an array of [File][1] objects.
 > Note: Whether the file input is for a single file or mulitple files,
 > it will always return an array of `File` objects upon selection.
 
-In its blockless form, it will render as a bare
-`input[type=file]`. Like this:
+In its blockless form, you will need to pass an `alt` attribute for
+the text you would like to be displayed inside the inputs label.
 
-<input type=file name="files" alt="Choose a File"/>
+``` handlebars
+{{x-file-input alt="hello world"}}
+```
 
-
-But that's kinda ugly! For beautiful file inputs, pass a block. This
-HTML will be used as the trigger of the file input.
+When passing a block, the HTML inside the block will be used as the
+trigger of the file input.
 
 ```hbs
 {{#x-file-input multiple=true action=(action "didSelectFiles")}}
@@ -106,7 +107,26 @@ In your CSS you need to add the following:
 ```
 
 And that's it! Your file input is now styled and decked to the nines!
-If you would like to see a real [life example checkout the demo page](http://thefrontside.github.io/emberx-file-input)
+If you would like to see a real
+[life example checkout the demo page](http://thefrontside.github.io/emberx-file-input)
+
+## Resetting the input
+
+If you would like to select the same file many times you need to call
+the `resetInput` method that's passed as an argument with the
+action. For example:
+
+``` javascript
+actions: {
+  myAction(files, resetInput) {
+    // Do something with your files.
+    // Once you're done, call the reset method:
+    resetInput();
+    // Now your input is reset!
+  }
+}
+```
+
 
 
 ## EmberX

--- a/README.md
+++ b/README.md
@@ -112,9 +112,8 @@ If you would like to see a real
 
 ## Resetting the input
 
-If you would like to select the same file many times you need to call
-the `resetInput` method that's passed as an argument with the
-action. For example:
+To select the same file many times you need to call the `resetInput`
+method that's passed as an argument with the action. For example:
 
 ``` javascript
 actions: {

--- a/addon/components/x-file-input.js
+++ b/addon/components/x-file-input.js
@@ -17,7 +17,7 @@ export default Ember.Component.extend({
    * @param {$.Event} e Native change event
    */
   change(e) {
-    this.sendAction("action", e.target.files, this.resetInput);
+    this.sendAction("action", e.target.files, this.resetInput.bind(this));
   },
 
   /**

--- a/addon/components/x-file-input.js
+++ b/addon/components/x-file-input.js
@@ -17,9 +17,25 @@ export default Ember.Component.extend({
    * @param {$.Event} e Native change event
    */
   change(e) {
-    this.sendAction("action", e.target.files);
+    this.sendAction("action", e.target.files, this.resetInput);
   },
 
+  /**
+   * Resets the value of the input so you can select the same file
+   * multiple times.
+   *
+   * @method
+   */
+  resetInput() {
+    this.$('.x-file--input').val('');
+  },
+
+  /**
+   * Generates a random ID to relate the label to the input.
+   *
+   * @method
+   * @private
+   */
   randomId: Ember.computed(function() {
     return Math.random().toString(36).substring(7);
   })

--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,6 @@
     "chai-jquery": "~2.0.0",
     "ember-cli-shims": "0.1.1",
     "ember-cli-test-loader": "0.2.2",
-    "ember-qunit-notifications": "0.1.0"
+    "sinon-chai": "~2.8.0"
   }
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -9,6 +9,7 @@ module.exports = function(defaults) {
 
   app.import('vendor/style.css');
   app.import('bower_components/chai-jquery/chai-jquery.js', {type: 'test'});
+  app.import('bower_components/sinon-chai/lib/sinon-chai.js', {type: 'test'});
   /*
     This build file specifies the options for the dummy test app of this
     addon, located in `/tests/dummy`

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
+    "ember-sinon": "0.5.1",
     "loader.js": "^4.0.1"
   },
   "keywords": [

--- a/tests/acceptance/x-file-input-test.js
+++ b/tests/acceptance/x-file-input-test.js
@@ -84,14 +84,25 @@ describe('Acceptance: XFileInput', function() {
      *
      */
     beforeEach(function() {
+      let _this = this;
       this.resetComponent = getComponentById('spec-file-input-reset');
       // Spy on the resetInput method
-      this.resetComponent.resetInput = sinon.spy();
+      this.resetContext = null;
+      // Warning, using a fat arrow function will not work. It will set
+      // `this.resetContext` to the mocha test runner contect every time.
+      this.resetComponent.resetInput = sinon.spy(function() {
+        _this.resetContext = this;
+      });
+
       this.resetComponent.$('.x-file--input').trigger('change');
     });
 
     it("calls the reset method", function() {
       expect(this.resetComponent.resetInput).to.have.been.called;
+    });
+
+    it("has the correct context sent", function() {
+      expect(this.resetContext).to.deep.equal(this.resetComponent);
     });
   });
 });

--- a/tests/acceptance/x-file-input-test.js
+++ b/tests/acceptance/x-file-input-test.js
@@ -4,6 +4,7 @@ import { beforeEach, afterEach } from '../test-helper';
 import { expect } from 'chai';
 import Ember from 'ember';
 import startApp from '../helpers/start-app';
+import sinon from 'sinon';
 
 var App;
 
@@ -68,6 +69,29 @@ describe('Acceptance: XFileInput', function() {
 
     it("binds the accept attribute on the native file input", function() {
       expect(this.component.$('input[type=file]')).to.have.attr('accept', 'image/jpg');
+    });
+  });
+
+  describe("Resetting the input", function() {
+
+    /*
+     * Since testing file inputs is basically impossible due to
+     * security reasons, this test just asserts that when you trigger
+     * the "change" event on the input it invokes the action & sends
+     * the reset function with it. In that action we invoke the
+     * `reset` method. Then we spy on that method and assert that it was
+     * called. That's about all we can do to test this.
+     *
+     */
+    beforeEach(function() {
+      this.resetComponent = getComponentById('spec-file-input-reset');
+      // Spy on the resetInput method
+      this.resetComponent.resetInput = sinon.spy();
+      this.resetComponent.$('.x-file--input').trigger('change');
+    });
+
+    it("calls the reset method", function() {
+      expect(this.resetComponent.resetInput).to.have.been.called;
     });
   });
 });

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -8,5 +8,11 @@ export default Ember.Controller.extend({
     let url = this.get('photoPreviewUrl');
 
     return Ember.String.htmlSafe(`background-image: url("${url}")`);
-  })
+  }),
+
+  actions: {
+    doSomething(files, reset) {
+      reset();
+    }
+  }
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -36,3 +36,8 @@
     </p>
   {{/each}}
 </div>
+
+<div class="demo-wrapper">
+  {{x-file-input alt="Upload Reset" action="doSomething"
+    id="spec-file-input-reset" class="custom-class"}}
+</div>


### PR DESCRIPTION
## What?

When the `action` is called we now send a second argument that is a function. This function is a reset function that you can invoke after you've finished working with your FileList blob.

The reset function just resets the value of the file input to an empty string, allowing you to select the same file as many times as you want.

This will close #23

## Why this way?

We explored many different options: resetting the input right after the action is fired, requiring the user to return a promise in the action once they're done, pass the component with the action and allow you to reset it yourself, etc. 

The main issue that we ran into is we could never ensure the integrity of the file object once the reset happened. And some of the other ways we tried were too confusing. 

What we decided upon was to send a `resetInput` function as a second argument in the action that allows **you** to reset the input after you've finished with the files. This ensures the file list is intact when you want to do stuff with it and doesn't require any confusing syntax. 

CC: @davekaro / @netes