### PR TITLE
Remove `ember-cli-import-polyfill` addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,6 @@ module.exports = {
   included: function(app) {
     this._super.included(app);
 
-    this.import('vendor/style.css');
+    app.import('vendor/style.css');
   }
 };

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-    "ember-cli-import-polyfill": "0.1.0",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
     "ember-cli-mocha": "0.10.4",


### PR DESCRIPTION
This is only needed for ember apps that have not yet upgraded to
ember-cli 2.7+.

[Edward Faulkner](https://github.com/tomdale/ember-network/pull/7#issuecomment-222508610) says that the addons should never change. Only use this addon if the
consuming app has yet to upgrade to ember-cli 2.7.

This should fix #35 