### PR TITLE
Chrome CSS bug fix: make width 1px, not 0.

### DIFF
--- a/vendor/style.css
+++ b/vendor/style.css
@@ -1,7 +1,7 @@
 /* Hide the original input */
 .x-file--input {
-  width: 0px;
-  height: 0px;
+  width: 1px;
+  height: 0;
   max-width: 0;
   opacity: 0;
   overflow: hidden;


### PR DESCRIPTION
This collapses 250px of occupied dead space. Changing the width to 1px
does not seem to effect the other browsers either (they already rendered
it correctly).

See this ember twiddle for an example:
https://ember-twiddle.com/f258ce5ab1d1d163067fa1c3782b874c?openFiles=templates.application.hbs%2C

Thanks @RobIsHere!

Closes #33 