### PR TITLE
Use a plain <input> instead of {{input}}

### DIFF
--- a/addon/templates/components/x-file-input.hbs
+++ b/addon/templates/components/x-file-input.hbs
@@ -1,5 +1,5 @@
-{{input id=randomId type="file" class="x-file--input" name=name
-  disabled=disabled multiple=multiple tabindex=tabindex accept=accept}}
+<input type="file" id={{randomId}} class="x-file--input" name={{name}}
+  disabled={{disabled}} multiple={{multiple}} tabindex={{tabindex}} accept={{accept}}>
 
 <label for="{{randomId}}">
   {{#if hasBlock}}


### PR DESCRIPTION
I've found some problems in 2.10 and safari with the `{{input type="file"}}`. For some unknown reason the first time an `{{x-file-input}}` is rendered the type of the input is `text`, not `file`. It does work after a reload or after transitioning to ther area and coming back.

This is clearly a bug in Ember, but there is no reason to use `{{input}}` when `<input>` is faster and does also bypasses any bug in the `{{input}}` component might introduce.