### PR TITLE
adds test helpers for integration and unit tests

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,7 +2,9 @@
   "predef": [
     "document",
     "window",
-    "-Promise"
+    "-Promise",
+    "triggerEvent",
+    "$"
   ],
   "browser": true,
   "boss": true,

--- a/README.md
+++ b/README.md
@@ -137,7 +137,60 @@ actions: {
 }
 ```
 
+## Acceptance Testing
 
+You can use the `selectFile` async helper in acceptance tests to simulate file uploads.
+
+First import the helper in your `test-helper.js` (or respective file that requires test dependencies)
+
+```javascript
+import 'emberx-file-input/test-helpers/select-file-async'
+
+...
+
+```
+
+then in your test:
+
+```javascript
+visit('/');
+selectFile('.x-file-input', {name: 'test.txt', type: 'text/plain'});
+
+andThen(function() {
+
+...
+```
+
+or if the code you're testing needs the object to be an actual file
+
+```javascript
+visit('/');
+
+const file = new Blob(['test'], {type: 'image/jpeg'});
+selectFile('.x-file-input', file);
+
+andThen(function() {
+
+...
+```
+
+The first argument is the class of your x-file-input component. The second argument is an object in place of the file normally returned.
+
+## Unit Testing
+
+There is a separate `selectFile` helper that works in unit/component tests.
+
+```javascript
+import 'emberx-file-input/test-helpers/select-file-unit'
+```
+
+then in your test:
+
+```javascript
+selectFile('.x-file-input', {name: 'test.txt', type: 'text/plain'});
+
+assert.equal($('.something').length, 1, 'Element exists!');
+```
 
 ## EmberX
 

--- a/addon/components/x-file-input.js
+++ b/addon/components/x-file-input.js
@@ -25,7 +25,7 @@ export default Ember.Component.extend({
    * @param {$.Event} e Native change event
    */
   change(e) {
-    this.sendAction("action", e.target.files, this.resetInput.bind(this));
+    this.sendAction("action", this.files(e), this.resetInput.bind(this));
   },
 
   /**
@@ -46,5 +46,24 @@ export default Ember.Component.extend({
    */
   randomId: Ember.computed(function() {
     return Math.random().toString(36).substring(7);
-  })
+  }),
+
+  /**
+   * Gets files from event object.
+   *
+   * @method
+   * @private
+   * @param {$.Event || Event}
+   */
+  files(e) {
+    if (e.target.files) {
+      return e.target.files;
+    } else if (e.testingFiles) {
+      return e.testingFiles;
+    } else {
+      // testingFiles will not exist on e
+      // when it is a JQuery.Event
+      return e.originalEvent.testingFiles;
+    }
+  }
 });

--- a/addon/test-helpers/select-file-async.js
+++ b/addon/test-helpers/select-file-async.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default Ember.Test.registerAsyncHelper('selectFile', function(app, selector, file) {
+  return triggerEvent(
+    selector,
+    'change',
+    { testingFiles: [file] }
+  );
+});

--- a/addon/test-helpers/select-file-unit.js
+++ b/addon/test-helpers/select-file-unit.js
@@ -1,0 +1,11 @@
+function buildChangeEvent(options = {}) {
+  let event = document.createEvent('Events');
+  event.initEvent('change', true, true);
+  $.extend(event, options);
+  return event;
+}
+
+export default function(selector, file) {
+  let changeEvent = buildChangeEvent({ testingFiles: [file] });
+  $(selector)[0].dispatchEvent(changeEvent);
+}


### PR DESCRIPTION
Wasn't sure exactly how we wanted to test the new test helpers. Figured I would throw this up to get some feedback first. 

I could [expand on existing tests ](https://github.com/thefrontside/emberx-file-input/blob/master/tests/acceptance/x-file-input-test.js#L90-L97)to the use helper. Or test the helper separately.

How do you feel about the direction I took with this?

---

issue: https://github.com/thefrontside/emberx-file-input/issues/47